### PR TITLE
(WIP) Improve menu performance

### DIFF
--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -15,6 +15,7 @@ use Snowdog\Menu\Block\Menu as SnowdogBlockMenu;
 use Snowdog\Menu\Model\Menu\Node\Image\File as ImageFile;
 use Snowdog\Menu\Model\NodeTypeProvider;
 use Snowdog\Menu\Model\TemplateResolver;
+use Gene\ExtendedSnowdogMenu\Service\Performance\PreloadCategoryThumbnails;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -52,6 +53,7 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
         TemplateResolver $templateResolver,
         ImageFile $imageFile,
         Escaper $escaper,
+        private readonly PreloadCategoryThumbnails $preloadCategoryThumbnails,
         array $data = []
     ) {
         parent::__construct($context, $eventManager, $menuRepository, $nodeRepository, $nodeTypeProvider, $searchCriteriaFactory, $filterGroupBuilder, $templateResolver, $imageFile, $escaper, $data);
@@ -108,5 +110,39 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
             ->setAdditionalData($node->getAdditionalData());
 
         return $nodeBlock;
+    }
+
+    /**
+     * @param $level
+     * @param $parent
+     * @return array|mixed
+     */
+    public function getNodes($level = 0, $parent = null)
+    {
+        $nodes = parent::getNodes($level, $parent);
+        if ($level === 0 && !$this->bulkLoadedNodesData) {
+            $this->bulkLoadedNodesData = true;
+            $this->preloadCategoryThumbnails();
+        }
+        return $nodes;
+    }
+
+    /**
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function preloadCategoryThumbnails()
+    {
+        $nodesTree = $this->getNodesTree();
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($nodesTree), \RecursiveIteratorIterator::SELF_FIRST);
+
+        $flattenedData = [];
+        foreach ($iterator as $value) {
+            if ($value instanceof \Snowdog\Menu\Model\Menu\Node) {
+                $flattenedData[] = (int) $value->getContent();
+            }
+        }
+        $categoryIds = array_unique($flattenedData);
+        $this->preloadCategoryThumbnails->loadCategoryThumbnails($categoryIds);
     }
 }

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -27,6 +27,8 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
      */
     private $imageFile;
 
+    private $bulkLoadedNodesData = false;
+
     /**
      * Menu constructor.
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -58,7 +58,19 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
         private readonly PreloadCategoryThumbnails $preloadCategoryThumbnails,
         array $data = []
     ) {
-        parent::__construct($context, $eventManager, $menuRepository, $nodeRepository, $nodeTypeProvider, $searchCriteriaFactory, $filterGroupBuilder, $templateResolver, $imageFile, $escaper, $data);
+        parent::__construct(
+            $context,
+            $eventManager,
+            $menuRepository,
+            $nodeRepository,
+            $nodeTypeProvider,
+            $searchCriteriaFactory,
+            $filterGroupBuilder,
+            $templateResolver,
+            $imageFile,
+            $escaper,
+            $data
+        );
         $this->imageFile = $imageFile;
     }
 
@@ -136,7 +148,10 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
     private function preloadCategoryThumbnails()
     {
         $nodesTree = $this->getNodesTree();
-        $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($nodesTree), \RecursiveIteratorIterator::SELF_FIRST);
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveArrayIterator($nodesTree),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
 
         $flattenedData = [];
         foreach ($iterator as $value) {

--- a/Model/ResourceModel/AttributeValues.php
+++ b/Model/ResourceModel/AttributeValues.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace Gene\ExtendedSnowdogMenu\Model\ResourceModel;
+
+use Magento\Eav\Model\Config;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\DB\Sql\UnionExpression;
+use Magento\Framework\EntityManager\MetadataPool;
+
+class AttributeValues
+{
+    /**
+     * @var MetadataPool
+     */
+    private $metadataPool;
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param MetadataPool $metadataPool
+     * @param Config $config
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        MetadataPool $metadataPool,
+        Config $config
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->metadataPool = $metadataPool;
+        $this->config = $config;
+    }
+
+    /**
+     * Get attribute values for given entity type, entity IDs, attribute codes and store IDs
+     *
+     * @see \Magento\Eav\Model\ResourceModel\AttributeValue::getValues()
+     *
+     * This function is 99% the same as the above, except we have support for multiple entity_ids
+     *
+     * @param string $entityType
+     * @param array $entityId
+     * @param string[] $attributeCodes
+     * @param int[] $storeIds
+     * @return array
+     */
+    public function getValues(
+        string $entityType,
+        array $entityIds,
+        array $attributeCodes = [],
+        array $storeIds = []
+    ): array {
+        $metadata = $this->metadataPool->getMetadata($entityType);
+        $connection = $metadata->getEntityConnection();
+        $selects = [];
+        $attributeTables = [];
+        $attributes = [];
+        $allAttributes = $this->getEntityAttributes($entityType);
+        $result = [];
+        if ($attributeCodes) {
+            foreach ($attributeCodes as $attributeCode) {
+                $attributes[$attributeCode] = $allAttributes[$attributeCode];
+            }
+        } else {
+            $attributes = $allAttributes;
+        }
+
+        foreach ($attributes as $attribute) {
+            if (!$attribute->isStatic()) {
+                $attributeTables[$attribute->getBackend()->getTable()][] = $attribute->getAttributeId();
+            }
+        }
+
+        if ($attributeTables) {
+            foreach ($attributeTables as $attributeTable => $attributeIds) {
+                $select = $connection->select()
+                    ->from(
+                        ['t' => $attributeTable],
+                        ['*']
+                    )
+                    ->where($metadata->getLinkField() . ' in (?)', $entityIds)
+                    ->where('attribute_id IN (?)', $attributeIds);
+                if (!empty($storeIds)) {
+                    $select->where(
+                        'store_id IN (?)',
+                        $storeIds
+                    );
+                }
+                $selects[] = $select;
+            }
+
+            if (count($selects) > 1) {
+                $select = $connection->select();
+                $select->from(['u' => new UnionExpression($selects, Select::SQL_UNION_ALL, '( %s )')]);
+            } else {
+                $select = reset($selects);
+            }
+
+            $result = $connection->fetchAll($select);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get attribute of given entity type
+     *
+     * @param string $entityType
+     * @return array
+     */
+    private function getEntityAttributes(string $entityType): array
+    {
+        $metadata = $this->metadataPool->getMetadata($entityType);
+        $eavEntityType = $metadata->getEavEntityType();
+        return null === $eavEntityType ? [] : $this->config->getEntityAttributes($eavEntityType);
+    }
+}

--- a/Service/Performance/PreloadCategoryThumbnails.php
+++ b/Service/Performance/PreloadCategoryThumbnails.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace Gene\ExtendedSnowdogMenu\Service\Performance;
+
+use Gene\ExtendedSnowdogMenu\Model\ResourceModel\AttributeValues;
+use Magento\Store\Model\StoreManagerInterface;
+
+class PreloadCategoryThumbnails
+{
+    private $lookup = [];
+
+    public function __construct(
+        private readonly AttributeValues $attributeValue,
+        private readonly StoreManagerInterface $storeManager,
+    ) {
+
+    }
+
+    /**
+     * Bulk preload the category IDs
+     *
+     * @param array $categoryIds
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function loadCategoryThumbnails(array $categoryIds)
+    {
+        if (empty($categoryIds)) {
+            return;
+        }
+
+        $values = $this->attributeValue->getValues(
+            \Magento\Catalog\Api\Data\CategoryInterface::class,
+            $categoryIds,
+            ['menu_image_thumb'],
+            [$this->storeManager->getStore()->getId(), '0']
+        );
+
+        if (!empty($values)) {
+            foreach ($values as $row) {
+                if (isset($row['value'])) {
+                    if (isset($row['row_id'])) {
+                        $this->lookup[$row['row_id']] = $row['value'];
+                    } else {
+                        $this->lookup[$row['entity_id']] = $row['value'];
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $categoryId
+     * @return string|null
+     */
+    public function getThumbnailForCategoryId($categoryId)
+    {
+        return $this->lookup[$categoryId] ?? null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "snowdog/module-menu": "^2.24.1"
     },
     "type": "magento2-module",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "license": [
         "Proprietary"
     ],


### PR DESCRIPTION
On an instance with a large menu tree we had a lot of calls to the DB for thumbnail data like

```
SQL: SELECT `t`.* FROM `catalog_category_entity_varchar` AS `t` WHERE (row_id = 1307) AND (attribute_id IN ('123')) AND (store_id IN ('1', '0'))
SQL: SELECT `t`.* FROM `catalog_category_entity_varchar` AS `t` WHERE (row_id = 1171) AND (attribute_id IN ('123')) AND (store_id IN ('1', '0'))
SQL: SELECT `t`.* FROM `catalog_category_entity_varchar` AS `t` WHERE (row_id = 1491) AND (attribute_id IN ('123')) AND (store_id IN ('1', '0'))
SQL: SELECT `t`.* FROM `catalog_category_entity_varchar` AS `t` WHERE (row_id = 1366) AND (attribute_id IN ('123')) AND (store_id IN ('1', '0'))
```

I enabled the magento database logger, and got a before and after for this change. It's not a profile, but gives a good idea of how much less database work we're doing.
```
$ grep catalog_category_entity_varchar db.before.log  | wc -l
783
$ grep catalog_category_entity_varchar var/debug/db.log  | wc -l
20
```

Tested locally and looks good - re-opened for QA