### PR TITLE
added all snowmenu_node column definitions to fix install issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "snowdog/module-menu": "^2.24.1"
     },
     "type": "magento2-module",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "license": [
         "Proprietary"
     ],

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,7 +1,38 @@
 <?xml version="1.0"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="snowmenu_node" resource="default" comment="Snowdog Menu">
+        <column xsi:type="int" name="node_id" unsigned="true" nullable="false" identity="true"
+                comment="Node ID"/>
+        <column xsi:type="int" name="menu_id" unsigned="true" nullable="false" identity="false"
+                comment="Menu ID"/>
+        <column xsi:type="varchar" name="type" nullable="false" length="255" comment="Node Type"/>
+        <column xsi:type="text" name="content" nullable="true" comment="Node contents"/>
+        <column xsi:type="varchar" name="classes" nullable="true" length="255" comment="CSS class name"/>
+        <column xsi:type="int" name="parent_id" unsigned="true" nullable="true" identity="false"
+                comment="Parent Node ID"/>
+        <column xsi:type="int" name="position" unsigned="true" nullable="false" identity="false"
+                comment="Node position"/>
+        <column xsi:type="int" name="level" unsigned="true" nullable="false" identity="false"
+                comment="Node level"/>
+        <column xsi:type="text" name="title" nullable="true" comment="Menu Title"/>
+        <column xsi:type="timestamp" name="creation_time" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Creation Time"/>
+        <column xsi:type="timestamp" name="update_time" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Modification Time"/>
+        <column xsi:type="smallint" name="is_active" unsigned="false" nullable="false" identity="false"
+                default="1" comment="Is Active"/>
+        <column xsi:type="tinyint" name="target" unsigned="false" nullable="true" identity="false"
+                default="0" comment="Target"/>
+        <column xsi:type="varchar" name="submenu_template" nullable="true" length="255" comment="Submenu Template"/>
+        <column xsi:type="varchar" name="node_template" nullable="true" length="255" comment="Node Template"/>
+        <column xsi:type="text" name="image" nullable="true" comment="Image"/>
+        <column xsi:type="text" name="image_alt_text" nullable="true" comment="Image Alt Text"/>
+        <column xsi:type="smallint" name="selected_item_id" unsigned="true" nullable="true" identity="false"
+                comment="Selected Item Id"/>
         <column xsi:type="text" name="font_color" nullable="true" comment="Font Color"/>
         <column xsi:type="text" name="font_weight" nullable="true" comment="Font Weight"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="node_id"/>
+        </constraint>
     </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -1,6 +1,24 @@
 {
     "snowmenu_node": {
         "column": {
+            "node_id": true,
+            "menu_id": true,
+            "type": true,
+            "content": true,
+            "classes": true,
+            "parent_id": true,
+            "position": true,
+            "level": true,
+            "title": true,
+            "creation_time": true,
+            "update_time": true,
+            "is_active": true,
+            "target": true,
+            "submenu_template": true,
+            "node_template": true,
+            "image": true,
+            "image_alt_text": true,
+            "selected_item_id": true,
             "font_color": true,
             "font_weight": true
         }


### PR DESCRIPTION
clean install of snowdog menu module breaks with following error:
`Installing schema... Upgrading schema... Column "title" does not exist in table "snowmenu_node".`
This is due to missing definitions within this modules db_schema.xml because of the way Magento prioritises setup install/upgrade schema files and db_schema definitions.