### PR TITLE
Update the module, based on the snowdog_menu changes

### DIFF
--- a/Block/Adminhtml/Edit/Tab/Nodes.php
+++ b/Block/Adminhtml/Edit/Tab/Nodes.php
@@ -9,6 +9,7 @@ use Magento\Framework\Registry;
 use Snowdog\Menu\Api\NodeRepositoryInterface;
 use Snowdog\Menu\Block\Adminhtml\Edit\Tab\Nodes as SnowdogTabNodes;
 use Snowdog\Menu\Controller\Adminhtml\Menu\Edit;
+use Snowdog\Menu\Model\CustomerGroupsProvider;
 use Snowdog\Menu\Model\Menu\Node\Image\File as ImageFile;
 use Snowdog\Menu\Model\NodeTypeProvider;
 use Snowdog\Menu\Model\VueProvider;
@@ -52,9 +53,10 @@ class Nodes extends SnowdogTabNodes implements TabInterface
         NodeTypeProvider $nodeTypeProvider,
         Registry $registry,
         VueProvider $vueProvider,
+        CustomerGroupsProvider $customerGroupsProvider,
         array $data = []
     ) {
-        parent::__construct($context, $nodeRepository, $imageFile, $nodeTypeProvider, $registry, $vueProvider, $data);
+        parent::__construct($context, $nodeRepository, $imageFile, $nodeTypeProvider, $registry, $vueProvider, $customerGroupsProvider, $data);
         $this->registry = $registry;
         $this->nodeRepository = $nodeRepository;
         $this->imageFile = $imageFile;

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -39,8 +39,6 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
      * @param MenuRepositoryInterface $menuRepository
      * @param NodeRepositoryInterface $nodeRepository
      * @param NodeTypeProvider $nodeTypeProvider
-     * @param SearchCriteriaFactory $searchCriteriaFactory
-     * @param FilterGroupBuilder $filterGroupBuilder
      * @param TemplateResolver $templateResolver
      * @param ImageFile $imageFile
      * @param Escaper $escaper
@@ -54,13 +52,13 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
         MenuRepositoryInterface $menuRepository,
         NodeRepositoryInterface $nodeRepository,
         NodeTypeProvider $nodeTypeProvider,
-        SearchCriteriaFactory $searchCriteriaFactory,
-        FilterGroupBuilder $filterGroupBuilder,
         TemplateResolver $templateResolver,
         ImageFile $imageFile,
         Escaper $escaper,
         private readonly PreloadCategoryThumbnails $preloadCategoryThumbnails,
         private readonly CategoryNode $categoryNode,
+        \Magento\Framework\App\Http\Context $httpContext,
+        array $nodeTypeCaches = [],
         array $data = []
     ) {
         parent::__construct(
@@ -69,11 +67,11 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
             $menuRepository,
             $nodeRepository,
             $nodeTypeProvider,
-            $searchCriteriaFactory,
-            $filterGroupBuilder,
             $templateResolver,
             $imageFile,
             $escaper,
+            $httpContext,
+            $nodeTypeCaches,
             $data
         );
         $this->imageFile = $imageFile;
@@ -125,8 +123,12 @@ class Menu extends SnowdogBlockMenu implements IdentityInterface
             ->setImage($node->getImage())
             ->setImageUrl($node->getImage() ? $this->imageFile->getUrl($node->getImage()) : null)
             ->setImageAltText($node->getImageAltText())
+            ->setImageWidth($node->getImageWidth())
+            ->setImageHeight($node->getImageHeight())
             ->setCustomTemplate($node->getNodeTemplate())
-            ->setAdditionalData($node->getAdditionalData());
+            ->setAdditionalData($node->getAdditionalData())
+            ->setSelectedItemId($node->getSelectedItemId())
+            ->setCustomerGroups($node->getCustomerGroups());
 
         return $nodeBlock;
     }

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,9 @@
     "description": "Extended functionality of snowdog menu extension based on our requirement",
     "require": {
         "magento/framework": "*",
-        "snowdog/module-menu": "^2.24.1"
+        "snowdog/module-menu": "^2.29.0"
     },
     "type": "magento2-module",
-    "version": "1.0.12",
     "license": [
         "Proprietary"
     ],

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,34 +1,6 @@
 <?xml version="1.0"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="snowmenu_node" resource="default" comment="Snowdog Menu">
-        <column xsi:type="int" name="node_id" unsigned="true" nullable="false" identity="true"
-                comment="Node ID"/>
-        <column xsi:type="int" name="menu_id" unsigned="true" nullable="false" identity="false"
-                comment="Menu ID"/>
-        <column xsi:type="varchar" name="type" nullable="false" length="255" comment="Node Type"/>
-        <column xsi:type="text" name="content" nullable="true" comment="Node contents"/>
-        <column xsi:type="varchar" name="classes" nullable="true" length="255" comment="CSS class name"/>
-        <column xsi:type="int" name="parent_id" unsigned="true" nullable="true" identity="false"
-                comment="Parent Node ID"/>
-        <column xsi:type="int" name="position" unsigned="true" nullable="false" identity="false"
-                comment="Node position"/>
-        <column xsi:type="int" name="level" unsigned="true" nullable="false" identity="false"
-                comment="Node level"/>
-        <column xsi:type="text" name="title" nullable="true" comment="Menu Title"/>
-        <column xsi:type="timestamp" name="creation_time" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
-                comment="Creation Time"/>
-        <column xsi:type="timestamp" name="update_time" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
-                comment="Modification Time"/>
-        <column xsi:type="smallint" name="is_active" unsigned="false" nullable="false" identity="false"
-                default="1" comment="Is Active"/>
-        <column xsi:type="tinyint" name="target" unsigned="false" nullable="true" identity="false"
-                default="0" comment="Target"/>
-        <column xsi:type="varchar" name="submenu_template" nullable="true" length="255" comment="Submenu Template"/>
-        <column xsi:type="varchar" name="node_template" nullable="true" length="255" comment="Node Template"/>
-        <column xsi:type="text" name="image" nullable="true" comment="Image"/>
-        <column xsi:type="text" name="image_alt_text" nullable="true" comment="Image Alt Text"/>
-        <column xsi:type="smallint" name="selected_item_id" unsigned="true" nullable="true" identity="false"
-                comment="Selected Item Id"/>
         <column xsi:type="text" name="font_color" nullable="true" comment="Font Color"/>
         <column xsi:type="text" name="font_weight" nullable="true" comment="Font Weight"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -1,24 +1,6 @@
 {
     "snowmenu_node": {
         "column": {
-            "node_id": true,
-            "menu_id": true,
-            "type": true,
-            "content": true,
-            "classes": true,
-            "parent_id": true,
-            "position": true,
-            "level": true,
-            "title": true,
-            "creation_time": true,
-            "update_time": true,
-            "is_active": true,
-            "target": true,
-            "submenu_template": true,
-            "node_template": true,
-            "image": true,
-            "image_alt_text": true,
-            "selected_item_id": true,
             "font_color": true,
             "font_weight": true
         }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -5,7 +5,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Gene\ExtendedSnowdogMenu\Api\Data\NodeInterface" type="Gene\ExtendedSnowdogMenu\Model\Node" />
     <preference for="Snowdog\Menu\Block\Adminhtml\Edit\Tab\Nodes" type="Gene\ExtendedSnowdogMenu\Block\Adminhtml\Edit\Tab\Nodes" />
     <preference for="Snowdog\Menu\Block\Menu" type="Gene\ExtendedSnowdogMenu\Block\Menu" />
     <preference for="Snowdog\Menu\Service\Menu\SaveRequestProcessor" type="Gene\ExtendedSnowdogMenu\Service\Menu\SaveRequestProcessor" />


### PR DESCRIPTION
# What has been done
1. Updated constructor params to be able to call the parent one
2. Updated `getMenuNodeBlock` method to include new snowdob features
3. Deleted preference, magento `s:d:c` complains about
4. Updated composer.json:
4.1. Updated the snowdog version requirements
4.2. Deleted hardcoded version